### PR TITLE
Fix typos in Quarto python code examples

### DIFF
--- a/reproducible-notebooks.qmd
+++ b/reproducible-notebooks.qmd
@@ -47,10 +47,10 @@ A code chunk is a special block where you write code, and Quarto will run it and
 
 ````
 ```{{python}}
-
 import matplotlib.pyplot as plt
 
-plt.plot([1,lt.show()])
+plt.plot([1, 3, 2])
+plt.show()
 ```
 ````
 
@@ -64,10 +64,11 @@ When your code creates a plot or image, Quarto automatically includes it as a *f
 
 ````
 ```{{python}}
-#\| label: fig-simple
-#\| fig-cap: "A simple line plot"
-#\| fig-alt: "Here is where to put alt text"
-plt.plot([1,lt.show()])
+#| label: fig-simple
+#| fig-cap: "A simple line plot"
+#| fig-alt: "Here is where to put alt text"
+plt.plot([1, 3, 2])
+plt.show()
 ```
 ````
 
@@ -79,13 +80,15 @@ You can also create tables from your data using code. Quarto will display the ta
 
 ````
 ```{{python}}
-#\| label: tbl-sample
-#\| tbl-cap: "Example of a simple data table"
+#| label: tbl-sample
+#| tbl-cap: "Example of a simple data table"
 import pandas as pd
 
 data = {
     "Species": ["Oak", "Pine", "Birch"],
-    "Height_m": [20, = pd.DataFrame(data)]}
+    "Height_m": [20, 15, 10],
+}
+df = pd.DataFrame(data)
 df
 ```
 ````

--- a/reproducible-notebooks.qmd
+++ b/reproducible-notebooks.qmd
@@ -46,7 +46,7 @@ Below the YAML block, you write your main content using Markdown, a simple way t
 A code chunk is a special block where you write code, and Quarto will run it and show the results in your document. Code chunks start and end with three backticks (\`\`\`) and the language you are using:
 
 ````
-```Python
+```{{python}}
 
 import matplotlib.pyplot as plt
 
@@ -63,7 +63,7 @@ You can also add options to your code chunk. For example, adding `echo: false` a
 When your code creates a plot or image, Quarto automatically includes it as a *figure*. You can add a caption, a short description under the figure, and a label, a name you use to refer to the figure later, by adding special lines at the top of your code chunk. For example:
 
 ````
-```
+```{{python}}
 #\| label: fig-simple
 #\| fig-cap: "A simple line plot"
 #\| fig-alt: "Here is where to put alt text"
@@ -78,7 +78,7 @@ This will show the plot with the caption "A simple line plot" underneath; you ca
 You can also create tables from your data using code. Quarto will display the table in your document, and you can add captions and labels just like with figures. For example, if you are using Python with the `pandas` library, you can create a small data table and show it in your notebook like this:
 
 ````
-```
+```{{python}}
 #\| label: tbl-sample
 #\| tbl-cap: "Example of a simple data table"
 import pandas as pd


### PR DESCRIPTION
Fixes #1

I put some reasonable numbers for the data examples, as I wasn't sure what they were before.